### PR TITLE
Fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@
 # Use new container based environment
 sudo: false
 
+dist: trusty
+
 # Declare project language.
 # @link http://about.travis-ci.org/docs/user/languages/php/
 language: php
@@ -15,18 +17,20 @@ matrix:
   include:
     # aliased to 5.2.17
     - php: '5.2'
+      dist: precise
       env: LTPHPFIVEFOUR=1
     # aliased to 5.3.29
     - php: '5.3'
+      dist: precise
       env: LTPHPFIVEFOUR=1
     - php: '5.4'
       env: GTEPHPFIVEFOUR=1
     - php: '5.5'
-      env: GTEPHPFIVEFOUR=1 SNIFF=1
+      env: GTEPHPFIVEFOUR=1
     - php: '5.6'
       env: GTEPHPFIVEFOUR=1
     - php: '7.0'
-      env: GTEPHPFIVEFOUR=1
+      env: GTEPHPFIVEFOUR=1 SNIFF=1
     - php: '7.1'
       env: GTEPHPFIVEFOUR=1
     - php: 'hhvm'
@@ -43,18 +47,19 @@ matrix:
 before_install:
     - export PHPCS_DIR=/tmp/phpcs
     - export WPCS_DIR=/tmp/wpcs
-    - export PHPCOMPAT_DIR=/tmp/wpcs/PHPCompatibility
+    - export PHPCOMPAT_DIR=/tmp/phpcompatibility
     # Install CodeSniffer for WordPress Coding Standards checks.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
     # Install WordPress Coding Standards.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
+    # Temporarily set to `develop` to benefit from PHPCS 3.x compatibility. Move back to `master` once released.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b develop --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
     # Install PHPCompatibility Standards in a subdirectory of WPCS so we only need to run installed_paths once.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
     # Hop into CodeSniffer directory.
     - if [[ "$SNIFF" == "1" ]]; then cd $PHPCS_DIR; fi
     # Set install path for WordPress Coding Standards.
     # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $WPCS_DIR; fi
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR; fi
     # Hop back into project dir.
     - if [[ "$SNIFF" == "1" ]]; then cd $TRAVIS_BUILD_DIR; fi
     # After CodeSniffer install you should refresh your path.
@@ -76,13 +81,5 @@ script:
     - if [[ "$SNIFF" == "1" ]]; then jshint .; fi
     # Run through JavaScript Code Style checker.
     - if [[ "$SNIFF" == "1" ]]; then jscs .; fi
-    # WordPress Coding Standards.
-    # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
-    # @link http://pear.php.net/package/PHP_CodeSniffer/
-    # -p flag: Show progress of the run.
-    # -s flag: Show sniff codes in all reports.
-    # -v flag: Print verbose output.
-    # -n flag: Do not print warnings. (shortcut for --warning-severity=0)
-    # --standard: Use WordPress as the standard.
-    # --extensions: Only sniff PHP files.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p -s -v -n . --standard=./ruleset.xml --extensions=php; fi
+    # Check code style against custom ruleset.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs . --runtime-set ignore_warnings_on_exit 1; fi

--- a/bin/generate-sitemaps.php
+++ b/bin/generate-sitemaps.php
@@ -193,9 +193,9 @@ class CheatsheetSitemap {
 	protected function order_entries() {
 		// Obtain a list of columns.
 		foreach ( $this->entries as $key => $info ) {
-		    $sort_order[ $key ] = $info['sort_order'];
-		    $prio[ $key ]       = $info['prio'];
-		    $url[ $key ]        = $info['url'];
+			$sort_order[ $key ] = $info['sort_order'];
+			$prio[ $key ]       = $info['prio'];
+			$url[ $key ]        = $info['url'];
 		}
 
 		// Sort the data with volume descending, edition ascending.
@@ -352,4 +352,4 @@ class CheatsheetSitemap {
 	}
 }
 
-new CheatsheetSitemap;
+new CheatsheetSitemap();

--- a/class.vartype-compare.php
+++ b/class.vartype-compare.php
@@ -185,7 +185,7 @@ class VartypeCompare extends Vartype {
 			'notes'         => array(
 				'<p><strong>Please note:</strong> <code>min() / max()</code> will evaluate a non-numeric string as 0 if compared to integer, but still return the string if it\'s seen as the numerically lowest/highest value.</p>',
 				'<p><code>max()</code> returns the numerically highest of the parameter values. If multiple values can be considered of the same size, the one that is listed first will be returned.<br />
-				 If <code>max()</code> is given multiple arrays, the longest array is returned. If all the arrays have the same length, <code>max()</code> will use lexicographic ordering to find the return value.</p>',
+				If <code>max()</code> is given multiple arrays, the longest array is returned. If all the arrays have the same length, <code>max()</code> will use lexicographic ordering to find the return value.</p>',
 			),
 		),
 	);

--- a/class.vartype-test.php
+++ b/class.vartype-test.php
@@ -1030,69 +1030,69 @@ class VartypeTest extends Vartype {
 		/**
 		 * Arithmetic operations.
 		 */
-		'pre_increment'		=> array(
+		'pre_increment'     => array(
 			'title'         => '$x = ++$x',
 			'url'           => 'http://php.net/language.operators.increment',
 			'arg'           => '$x',
 			'function'      => '$r = ++$x; if ( is_int( $r ) ) { pr_int( $r ); } else if ( is_float( $r ) ) { pr_flt( $r ); } else { pr_var( $r, \'\', true, true ); }',
 			'notes'         => array(
-				'<p>Please take note: using the in-/decrementors on SplInt and SplFloat objects may give unexpected (inconsistent) results....</p>'
+				'<p>Please take note: using the in-/decrementors on SplInt and SplFloat objects may give unexpected (inconsistent) results....</p>',
 			),
 		),
-		'post_increment'		=> array(
+		'post_increment'    => array(
 			'title'         => '$x = $x++',
 			'url'           => 'http://php.net/language.operators.increment',
 			'arg'           => '$x',
 			'function'      => '$r = $x++; if ( is_int( $r ) ) { pr_int( $r ); } else if ( is_float( $r ) ) { pr_flt( $r ); } else { pr_var( $r, \'\', true, true ); }',
 			'notes'         => array(
-				'<p>Please take note: using the in-/decrementors on SplInt and SplFloat objects may give unexpected (inconsistent) results....</p>'
+				'<p>Please take note: using the in-/decrementors on SplInt and SplFloat objects may give unexpected (inconsistent) results....</p>',
 			),
 		),
-		'pre_decrement'		=> array(
+		'pre_decrement'     => array(
 			'title'         => '$x = --$x',
 			'url'           => 'http://php.net/language.operators.increment',
 			'arg'           => '$x',
 			'function'      => '$r = --$x; if ( is_int( $r ) ) { pr_int( $r ); } else if ( is_float( $r ) ) { pr_flt( $r ); } else { pr_var( $r, \'\', true, true ); }',
 			'notes'         => array(
-				'<p>Please take note: using the in-/decrementors on SplInt and SplFloat objects may give unexpected (inconsistent) results....</p>'
+				'<p>Please take note: using the in-/decrementors on SplInt and SplFloat objects may give unexpected (inconsistent) results....</p>',
 			),
 		),
-		'post_decrement'		=> array(
+		'post_decrement'    => array(
 			'title'         => '$x = $x--',
 			'url'           => 'http://php.net/language.operators.increment',
 			'arg'           => '$x',
 			'function'      => '$r = $x--; if ( is_int( $r ) ) { pr_int( $r ); } else if ( is_float( $r ) ) { pr_flt( $r ); } else { pr_var( $r, \'\', true, true ); }',
 			'notes'         => array(
-				'<p>Please take note: using the in-/decrementors on SplInt and SplFloat objects may give unexpected (inconsistent) results....</p>'
+				'<p>Please take note: using the in-/decrementors on SplInt and SplFloat objects may give unexpected (inconsistent) results....</p>',
 			),
 		),
 
 
-		'arithmetic_negate'		=> array(
+		'arithmetic_negate'   => array(
 			'title'         => '-$x',
 			'url'           => 'http://php.net/language.operators.arithmetic',
 			'arg'           => '$x',
 			'function'      => 'if ( ! is_array( $x ) && ( PHP_VERSION_ID > 50005 || ! is_object( $x ) ) ) { pr_var( -$x, \'\', true, true ); } else { trigger_error( \'Unsupported operand types\', E_USER_ERROR ); }',
 		),
-		'arithmetic_subtract'	=> array(
+		'arithmetic_subtract' => array(
 			'title'         => '$x&nbsp;-&nbsp;0',
 			'url'           => 'http://php.net/language.operators.arithmetic',
 			'arg'           => '$x',
 			'function'      => 'if ( ! is_array( $x ) && ( PHP_VERSION_ID > 50005 || ! is_object( $x ) ) ) { pr_var( $x - 0, \'\', true, true ); } else { trigger_error( \'Unsupported operand types\', E_USER_ERROR ); }',
 		),
-		'arithmetic_multiply'	=> array(
+		'arithmetic_multiply' => array(
 			'title'         => '$x&nbsp;*&nbsp;1',
 			'url'           => 'http://php.net/language.operators.arithmetic',
 			'arg'           => '$x',
 			'function'      => 'if ( ! is_array( $x ) && ( PHP_VERSION_ID > 50005 || ! is_object( $x ) ) ) { pr_var( $x * 1, \'\', true, true ); } else { trigger_error( \'Unsupported operand types\', E_USER_ERROR ); }',
 		),
-		'arithmetic_divide'		=> array(
+		'arithmetic_divide'   => array(
 			'title'         => '$x&nbsp;/&nbsp;1',
 			'url'           => 'http://php.net/language.operators.arithmetic',
 			'arg'           => '$x',
 			'function'      => 'if ( ! is_array( $x ) && ( PHP_VERSION_ID > 50005 || ! is_object( $x ) ) ) { pr_var( $x / 1, \'\', true, true ); } else { trigger_error( \'Unsupported operand types\', E_USER_ERROR ); }',
 		),
-		'arithmetic_modulus'	=> array(
+		'arithmetic_modulus'  => array(
 			'title'         => '$x&nbsp;%&nbsp;1',
 			'url'           => 'http://php.net/language.operators.arithmetic',
 			'arg'           => '$x',
@@ -1191,7 +1191,7 @@ class VartypeTest extends Vartype {
 			'arg'           => '$x',
 			'function'      => '$valid = preg_match( \'`^\w+$`u\', $x ); if ( $valid === 1 ) { pr_bool( true ); } else if ( $valid === 0 ) { pr_bool( false ); } else if ( $valid === false ) { print \'Error\'; } else { pr_var( $valid, \'\', true, true ); }',
 			'notes'         => array(
-				'<p>What <code>\w</code> matches is locale dependent. The locale for these cheatsheets are set to <code>C</code>. Results with other locales will vary.</p>'
+				'<p>What <code>\w</code> matches is locale dependent. The locale for these cheatsheets are set to <code>C</code>. Results with other locales will vary.</p>',
 			),
 		),
 
@@ -1982,7 +1982,7 @@ else {
 
 		'string_casting'    => array(
 			'title'     => 'String casting',
-			'tests'	    => array(
+			'tests'     => array(
 				'settype_string',
 				'string',
 				'strval',
@@ -2107,7 +2107,7 @@ else {
 
 		'resource_tests'  => array(
 			'title'      => 'Resources',
-			'tests'	     => array(
+			'tests'      => array(
 				'is_resource',
 				'get_resource_type',
 			),
@@ -2122,7 +2122,7 @@ else {
 
 		'arithmetic' => array(
 			'title'     => 'Basic Arithmetic',
-			'tests'	    => array(
+			'tests'     => array(
 				'pre_increment',
 				'post_increment',
 				'pre_decrement',
@@ -2188,7 +2188,7 @@ else {
 	var $filter_test_group = array(
 		'filter_extension_bool_int_float'   => array(
 			'title'     => 'Filter Extension - bool/int/float',
-			'tests'	    => array(
+			'tests'     => array(
 				'filter_combined_bool_null',
 
 				'filter_combined_int_null',
@@ -2212,7 +2212,7 @@ else {
 
 		'filter_extension_strings'   => array(
 			'title'     => 'Filter Extension - string',
-			'tests'	    => array(
+			'tests'     => array(
 				'filter_combined_string_null',
 				'filter_combined_str_null_sanitize',
 				'filter_combined_str_null_sanitize_encode',

--- a/include/xvardump.php
+++ b/include/xvardump.php
@@ -10,7 +10,7 @@
  * Only use those if you know what you are receiving and don't need variable typing info.
  *
  * @package xvardump
- * @author	Juliette Reinders Folmer, {@link http://www.adviesenzo.nl/ Advies en zo} -
+ * @author  Juliette Reinders Folmer, {@link http://www.adviesenzo.nl/ Advies en zo} -
  *  <xvardump@adviesenzo.nl>
  *
  * @version   1.7
@@ -265,7 +265,7 @@ function object_info( $obj, $escape, $short, $space ) {
 /**
  * Function to dump all defined variables.
  *
- * @uses	pr_var()
+ * @uses pr_var()
  */
 function dump_all() {
 	$var = get_defined_vars();

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,7 +1,10 @@
 <?xml version="1.0"?>
 <ruleset name="PHP Cheatsheets">
 	<description>PHP Cheatsheets rules for PHP_CodeSniffer</description>
-	
+
+	<arg value="sp"/>
+	<arg name="extensions" value="php"/>
+
 	<exclude-pattern>include/PHP-cast-to-type/*</exclude-pattern>
 
 	<!-- PHP cross-version compatibility -->
@@ -20,6 +23,12 @@
 		<exclude-pattern>class.vartype-php5.php</exclude-pattern>
 	</rule>
 	<rule ref="PHPCompatibility.PHP.NewFunctions.intdivFound">
+		<exclude-pattern>class.vartype-php7.php</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.PHP.NewClasses.exceptionFound">
+		<exclude-pattern>class.vartype-php5.php</exclude-pattern>
+	</rule>
+	<rule ref="PHPCompatibility.PHP.NewClasses.errorFound">
 		<exclude-pattern>class.vartype-php7.php</exclude-pattern>
 	</rule>
 	<!-- ... or explicitely part of the cheatsheets to demonstrate behaviour changes in PHP. -->
@@ -72,7 +81,13 @@
 
 	</rule>
 
-	<rule ref="WordPress.Arrays.ArrayDeclaration.ValueNoNewline">
+	<!-- Temporarily downgraded to warning because of a bug in the sniff which shouldn't break the build.
+		 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1064 -->
+	<rule ref="WordPress.Arrays.ArrayIndentation.MultiLineArrayItemNotAligned">
+		<type>warning</type>
+	</rule>
+
+	<rule ref="WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine">
 		<exclude-pattern>class.vartype.php</exclude-pattern>
 	</rule>
 

--- a/views/cheat-sheet-menu.php
+++ b/views/cheat-sheet-menu.php
@@ -14,15 +14,15 @@ if ( ! defined( 'APP_DIR' ) ) {
 ?>
 		<div id="main-menu">
 			<p>
-				<a href="<?php echo BASE_URI; ?>compare/" class="top-link<?php if ( $type === 'compare' ) { echo ' top-active'; } ?>">
+				<a href="<?php echo BASE_URI; ?>compare/" class="top-link<?php echo ( ( $type === 'compare' ) ? ' top-active' : '' ); ?>">
 					Variable&nbsp;Comparison<br />Cheat&nbsp;sheet
 					<img src="<?php echo BASE_URI; ?>page/images/screenshot-var-compare.png" width="220" height="220" alt="Variable Comparison Cheatsheet Screenshot" />
 				</a>
-				<a href="<?php echo BASE_URI; ?>arithmetic/" class="top-link<?php if ( $type === 'arithmetic' ) { echo ' top-active'; } ?>">
+				<a href="<?php echo BASE_URI; ?>arithmetic/" class="top-link<?php echo ( ( $type === 'arithmetic' ) ? ' top-active' : '' ); ?>">
 					Variable&nbsp;Arithmetic<br />Cheat&nbsp;sheet
 					<img src="<?php echo BASE_URI; ?>page/images/screenshot-var-arithm.png" width="220" height="220" alt="Variable Arithmetic Cheatsheet Screenshot" />
 				</a>
-				<a href="<?php echo BASE_URI; ?>test/" class="top-link<?php if ( $type === 'test' ) { echo ' top-active'; } ?>">
+				<a href="<?php echo BASE_URI; ?>test/" class="top-link<?php echo ( ( $type === 'test' ) ? ' top-active' : '' ); ?>">
 					Variable&nbsp;Testing<br />Cheat&nbsp;sheet
 					<img src="<?php echo BASE_URI; ?>page/images/screenshot-var-tests.png" width="220" height="220" alt="Variable Testing Cheatsheet Screenshot" />
 				</a>

--- a/views/header.php
+++ b/views/header.php
@@ -19,7 +19,8 @@ if ( ! defined( 'APP_DIR' ) ) {
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
 <?php
-if ( isset( $GLOBALS['autogen'] ) && $GLOBALS['autogen'] === true ) : ?>
+if ( isset( $GLOBALS['autogen'] ) && $GLOBALS['autogen'] === true ) :
+?>
 	<!-- This static cheatsheet was AUTO-GENERATED with PHP <?php echo htmlspecialchars( PHP_VERSION, ENT_QUOTES, 'UTF-8' ), ' - ', date( 'r' ); ?>-->
 
 <?php
@@ -46,15 +47,18 @@ if ( isset( $type ) ) {
 <?php
 unset( $meta_title );
 
-if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) : ?>
+if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) :
+?>
 	<link type="text/css" rel="stylesheet" href="<?php echo BASE_URI; ?>page/jquery-css/jquery-ui<?php echo $GLOBALS['min']; ?>.css" />
 	<link type="text/css" rel="stylesheet" href="<?php echo BASE_URI; ?>page/jquery-css/jquery-ui.theme<?php echo $GLOBALS['min']; ?>.css" />
 <?php
-endif; ?>
+endif;
+?>
 	<link type="text/css" rel="stylesheet" href="<?php echo BASE_URI; ?>page/style<?php echo $GLOBALS['min']; ?>.css" />
 
 <?php
-if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) : ?>
+if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) :
+?>
 	<!-- jQuery via CDN with local fall-back -->
 	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 	<script type="text/javascript">(window.jQuery) || document.write('\x3Cscript type="text/javascript" src="<?php echo BASE_URI; ?>page/jquery-css/jquery-1.11.2<?php echo $GLOBALS['min']; ?>.js">\x3C/script>')</script>
@@ -68,7 +72,8 @@ if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) : ?>
 	<!-- custom js -->
 	<script type="text/javascript" src="<?php echo BASE_URI; ?>page/interaction<?php echo $GLOBALS['min']; ?>.js"></script>
 <?php
-endif; ?>
+endif;
+?>
 
 
 	<link rel="start" href="http://phpcheatsheets.com/index.php" />
@@ -78,49 +83,57 @@ endif; ?>
 
 </head>
 <?php
-if ( ! isset( $GLOBALS['autogen'] ) || $GLOBALS['autogen'] !== true ) : ?>
+if ( ! isset( $GLOBALS['autogen'] ) || $GLOBALS['autogen'] !== true ) :
+?>
 <body>
 <?php
-else : ?>
+else :
+?>
 <body class="static-archive">
 <?php
-endif; ?>
+endif;
+?>
 
 <div class="head">
 
 <?php
-if ( isset( $GLOBALS['type'] ) ) : ?>
+if ( isset( $GLOBALS['type'] ) ) :
+?>
 	<div id="too-much">
 		<a href="http://www.google.com/search?q=fluffy+animals&amp;tbm=isch" target="_blank"><img src="<?php echo BASE_URI; ?>page/images/jakobwesthoff_3231273333_2473ef9cdf_s.jpg" width="75" height="75" alt="Fluffy ElePHPant" /></a>
 		<p>Too much ?</p>
 		<p><a href="http://www.google.com/search?q=fluffy+animals&amp;tbm=isch" target="_blank">Take a break and rest your eyes</a>.</p>
 	</div>
 <?php
-endif; ?>
+endif;
+?>
 	<a href="http://github.com/jrfnl/PHP-cheat-sheet-extended" class="forkme" title="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_orange_ff7600.png">&nbsp;</a>
 
 	<h1><a href="<?php echo BASE_URI; ?>"><img src="<?php echo BASE_URI; ?>page/images/php-med-trans.png" width="95" height="51" alt="PHP" /> Cheatsheets</a></h1>
 
 <?php
-if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) : ?>
+if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) :
+?>
 	<div id="main-menu">
 		<ul>
-			<li><a href="<?php echo BASE_URI; ?>compare/" class="top-link<?php if ( isset( $GLOBALS['type'] ) && $GLOBALS['type'] === 'compare' ) { echo ' top-active'; } ?>">Variable Comparisons</a></li>
-			<li><a href="<?php echo BASE_URI; ?>arithmetic/" class="top-link<?php if ( isset( $GLOBALS['type'] ) && $GLOBALS['type'] === 'arithmetic' ) { echo ' top-active'; } ?>">Variable Arithmetics</a></li>
-			<li><a href="<?php echo BASE_URI; ?>test/" class="top-link<?php if ( isset( $GLOBALS['type'] ) && $GLOBALS['type'] === 'test' ) { echo ' top-active'; } ?>">Variable Testing</a></li>
-			<li><a href="<?php echo BASE_URI; ?>other-cheat-sheets/" class="top-link<?php if ( isset( $GLOBALS['page'] ) && $GLOBALS['page'] === 'other-cheat-sheets' ) { echo ' top-active'; } ?>">More cheatsheets</a></li>
-			<li class="top-link-small"><a href="<?php echo BASE_URI; ?>about/" class="top-link<?php if ( isset( $GLOBALS['page'] ) && $GLOBALS['page'] === 'about' ) { echo ' top-active'; } ?>">About</a></li>
+			<li><a href="<?php echo BASE_URI; ?>compare/" class="top-link<?php echo ( ( isset( $GLOBALS['type'] ) && $GLOBALS['type'] === 'compare' ) ? ' top-active' : '' ); ?>">Variable Comparisons</a></li>
+			<li><a href="<?php echo BASE_URI; ?>arithmetic/" class="top-link<?php echo ( ( isset( $GLOBALS['type'] ) && $GLOBALS['type'] === 'arithmetic' ) ? ' top-active' : '' ); ?>">Variable Arithmetics</a></li>
+			<li><a href="<?php echo BASE_URI; ?>test/" class="top-link<?php echo ( ( isset( $GLOBALS['type'] ) && $GLOBALS['type'] === 'test' ) ? ' top-active' : '' ); ?>">Variable Testing</a></li>
+			<li><a href="<?php echo BASE_URI; ?>other-cheat-sheets/" class="top-link<?php echo ( ( isset( $GLOBALS['page'] ) && $GLOBALS['page'] === 'other-cheat-sheets' ) ? ' top-active' : '' ); ?>">More cheatsheets</a></li>
+			<li class="top-link-small"><a href="<?php echo BASE_URI; ?>about/" class="top-link<?php echo ( ( isset( $GLOBALS['page'] ) && $GLOBALS['page'] === 'about' ) ? ' top-active' : '' ); ?>">About</a></li>
 		</ul>
 	</div>
 <?php
-endif; ?>
+endif;
+?>
 </div>
 
 <div class="content-wrapper">
 	<div class="content">
 
 <?php
-if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) : ?>
+if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) :
+?>
 	<h2><?php echo htmlspecialchars( $GLOBALS['page_title'], ENT_QUOTES, 'UTF-8' ); ?></h2>
 
 <?php

--- a/views/notes-legend.php
+++ b/views/notes-legend.php
@@ -40,7 +40,8 @@ if ( ! defined( 'APP_DIR' ) ) {
 
 <?php
 include APP_DIR . '/include/vars-to-test.php';
-if ( is_array( $legend_array ) && $legend_array !== array() ) : ?>
+if ( is_array( $legend_array ) && $legend_array !== array() ) :
+?>
 
 			<h3>Notes on some variables:</h3>
 			<div>
@@ -51,17 +52,21 @@ if ( is_array( $legend_array ) && $legend_array !== array() ) : ?>
 						<th>How the variable is defined:</th>
 					</tr>
 
-<?php
-foreach ( $legend_array as $k => $v ) : ?>
+	<?php
+	foreach ( $legend_array as $k => $v ) :
+	?>
 					<tr>
 						<th id="var-legend-<?php echo $k; ?>"><?php echo $k; ?></th>
 						<td><code><?php echo $v; ?></code></td>
-					</tr><?php
-endforeach; ?>
+					</tr>
+	<?php
+	endforeach;
+	?>
 				</table>
 			</div>
 <?php
-endif; ?>
+endif;
+?>
 
 			<h3>Legend / How to use the tables:</h3>
 			<div>


### PR DESCRIPTION
PHPCS:
* Move PHPCS command line arguments to the ruleset.
* Show PHPCS warnings in build, but don't error on them.
* Do the code style check again PHP 7

Travis:
* Adjust the script to allow for the latest changes in the Travis infrastructure (trusty/precise).
* Adjust the way the PHPCompatibility standard is installed / PHPCompatibility v8.0.0.
* Adjust the paths to the phpcs command / PHPCS 3.x
* (Temporarily) use WPCS `develop` for PHPCS 3.x compatibility.

+ Minor code style fixes to comply with the latest versions of the standards.


