### PR TITLE
Travis: speed up build times by disabling Xdebug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,18 +35,19 @@ matrix:
       env: GTEPHPFIVEFOUR=1 SNIFF=1
     - php: '7.2'
       env: GTEPHPFIVEFOUR=1
-    - php: 'hhvm'
-      env: GTEPHPFIVEFOUR=1
     - php: 'nightly'
       env: GTEPHPFIVEFOUR=1
 
   allow_failures:
-    - php: 'hhvm'
     - php: 'nightly'
 
 # Use this to prepare your build for testing.
 # Failures in this section will result in build status 'errored'.
 before_install:
+    # Speed up build time by disabling Xdebug.
+    # https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/
+    - if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then phpenv config-rm xdebug.ini; fi
+    # Set up environment variables.
     - export PHPCS_DIR=/tmp/phpcs
     - export WPCS_DIR=/tmp/wpcs
     - export PHPCOMPAT_DIR=/tmp/phpcompatibility


### PR DESCRIPTION
As suggested by John Blackbourn in https://johnblackbourn.com/reducing-travis-ci-build-times-for-wordpress-projects/

Also remove HHVM build as HHVM is not covered by the cheatsheets anyway.