### PR TITLE
Gitattributes: don't package config files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,27 @@
-# Standards for multi-platform colaboration
+#
+# Exclude these files from release archives.
+# This will also make them unavailable when using Composer with `--prefer-dist`.
+# If you develop using Composer, use `--prefer-source`.
+# https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.jscsrc export-ignore
+/.jshintignore export-ignore
+/.jshintrc export-ignore
+/.phpcs.xml.dist export-ignore
+/.scrutinizer.yml export-ignore
+/.travis.yml export-ignore
+/bin export-ignore
 
+#
+# Auto detect text files and perform LF normalization
 # Set default behaviour, in case users don't have core.autocrlf set.
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
 * text=auto
+
+#
+# The above will handle all files NOT found below
+#
+*.md text
+*.php text


### PR DESCRIPTION
Exclude the dev tooling config files and the autogenerate tools from being included in release archives.