### PR TITLE
Revert "PHPCS: minor code style fixes"

### DIFF
--- a/views/header.php
+++ b/views/header.php
@@ -3,6 +3,8 @@
  * Template part: Page header.
  *
  * @package PHPCheatsheets
+ *
+ * @phpcs:disable Generic.WhiteSpace.ScopeIndent -- Fixing these creates trailing whitespace in the HTML output.
  */
 
 // Prevent direct calls to this file.
@@ -20,10 +22,10 @@ if ( ! defined( 'APP_DIR' ) ) {
 
 <?php
 if ( isset( $GLOBALS['autogen'] ) && $GLOBALS['autogen'] === true ) :
-	?>
+?>
 	<!-- This static cheatsheet was AUTO-GENERATED with PHP <?php echo htmlspecialchars( PHP_VERSION, ENT_QUOTES, 'UTF-8' ), ' - ', date( 'r' ); ?>-->
 
-	<?php
+<?php
 endif;
 $meta_title = htmlspecialchars( $GLOBALS['page_title'], ENT_QUOTES, 'UTF-8' );
 if ( isset( $GLOBALS['tab_title'] ) && $GLOBALS['tab_title'] !== '' ) {
@@ -48,17 +50,17 @@ if ( isset( $type ) ) {
 unset( $meta_title );
 
 if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) :
-	?>
+?>
 	<link type="text/css" rel="stylesheet" href="<?php echo BASE_URI; ?>page/jquery-css/jquery-ui<?php echo $GLOBALS['min']; ?>.css" />
 	<link type="text/css" rel="stylesheet" href="<?php echo BASE_URI; ?>page/jquery-css/jquery-ui.theme<?php echo $GLOBALS['min']; ?>.css" />
-	<?php
+<?php
 endif;
 ?>
 	<link type="text/css" rel="stylesheet" href="<?php echo BASE_URI; ?>page/style<?php echo $GLOBALS['min']; ?>.css" />
 
 <?php
 if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) :
-	?>
+?>
 	<!-- jQuery via CDN with local fall-back -->
 	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 	<script type="text/javascript">(window.jQuery) || document.write('\x3Cscript type="text/javascript" src="<?php echo BASE_URI; ?>page/jquery-css/jquery-1.11.2<?php echo $GLOBALS['min']; ?>.js">\x3C/script>')</script>
@@ -71,7 +73,7 @@ if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) :
 	<script type="text/javascript" src="<?php echo BASE_URI; ?>page/jquery.thfloat-0.7.2<?php echo $GLOBALS['min']; ?>.js"></script>
 	<!-- custom js -->
 	<script type="text/javascript" src="<?php echo BASE_URI; ?>page/interaction<?php echo $GLOBALS['min']; ?>.js"></script>
-	<?php
+<?php
 endif;
 ?>
 
@@ -84,13 +86,13 @@ endif;
 </head>
 <?php
 if ( ! isset( $GLOBALS['autogen'] ) || $GLOBALS['autogen'] !== true ) :
-	?>
+?>
 <body>
-	<?php
+<?php
 else :
-	?>
+?>
 <body class="static-archive">
-	<?php
+<?php
 endif;
 ?>
 
@@ -98,13 +100,13 @@ endif;
 
 <?php
 if ( isset( $GLOBALS['type'] ) ) :
-	?>
+?>
 	<div id="too-much">
 		<a href="http://www.google.com/search?q=fluffy+animals&amp;tbm=isch" target="_blank"><img src="<?php echo BASE_URI; ?>page/images/jakobwesthoff_3231273333_2473ef9cdf_s.jpg" width="75" height="75" alt="Fluffy ElePHPant" /></a>
 		<p>Too much ?</p>
 		<p><a href="http://www.google.com/search?q=fluffy+animals&amp;tbm=isch" target="_blank">Take a break and rest your eyes</a>.</p>
 	</div>
-	<?php
+<?php
 endif;
 ?>
 	<a href="http://github.com/jrfnl/PHP-cheat-sheet-extended" class="forkme" title="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_orange_ff7600.png">&nbsp;</a>
@@ -113,7 +115,7 @@ endif;
 
 <?php
 if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) :
-	?>
+?>
 	<div id="main-menu">
 		<ul>
 			<li><a href="<?php echo BASE_URI; ?>compare/" class="top-link<?php echo ( ( isset( $GLOBALS['type'] ) && $GLOBALS['type'] === 'compare' ) ? ' top-active' : '' ); ?>">Variable Comparisons</a></li>
@@ -123,7 +125,7 @@ if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) :
 			<li class="top-link-small"><a href="<?php echo BASE_URI; ?>about/" class="top-link<?php echo ( ( isset( $GLOBALS['page'] ) && $GLOBALS['page'] === 'about' ) ? ' top-active' : '' ); ?>">About</a></li>
 		</ul>
 	</div>
-	<?php
+<?php
 endif;
 ?>
 </div>
@@ -133,8 +135,8 @@ endif;
 
 <?php
 if ( isset( $GLOBALS['type'] ) || isset( $GLOBALS['page'] ) ) :
-	?>
+?>
 	<h2><?php echo htmlspecialchars( $GLOBALS['page_title'], ENT_QUOTES, 'UTF-8' ); ?></h2>
 
-	<?php
+<?php
 endif;

--- a/views/notes-legend.php
+++ b/views/notes-legend.php
@@ -3,6 +3,8 @@
  * Template part: Table legend.
  *
  * @package PHPCheatsheets
+ *
+ * @phpcs:disable Generic.WhiteSpace.ScopeIndent -- Fixing these creates trailing whitespace in the HTML output.
  */
 
 // Prevent direct calls to this file.
@@ -41,7 +43,7 @@ if ( ! defined( 'APP_DIR' ) ) {
 <?php
 include APP_DIR . '/include/vars-to-test.php';
 if ( is_array( $legend_array ) && $legend_array !== array() ) :
-	?>
+?>
 
 			<h3>Notes on some variables:</h3>
 			<div>
@@ -52,19 +54,19 @@ if ( is_array( $legend_array ) && $legend_array !== array() ) :
 						<th>How the variable is defined:</th>
 					</tr>
 
-	<?php
-	foreach ( $legend_array as $k => $v ) :
-		?>
+<?php
+foreach ( $legend_array as $k => $v ) :
+?>
 					<tr>
 						<th id="var-legend-<?php echo $k; ?>"><?php echo $k; ?></th>
 						<td><code><?php echo $v; ?></code></td>
 					</tr>
-		<?php
-	endforeach;
-	?>
+<?php
+endforeach;
+?>
 				</table>
 			</div>
-	<?php
+<?php
 endif;
 ?>
 


### PR DESCRIPTION
The CS fixes created undesired differences in the HTML output.
The offending sniff has now been disabled for these two files.

This reverts commit f8a9ed9d34701e4dceeb1142be566696b9f4f6b1.