### PR TITLE
CS: update the ruleset for newly released versions of the CS standards

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -5,6 +5,12 @@
 	<arg value="sp"/>
 	<arg name="extensions" value="php"/>
 
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check 8 files simultanously. -->
+	<arg name="parallel" value="8"/>
+
 	<file>.</file>
 
 	<exclude-pattern>include/PHP-cast-to-type/*</exclude-pattern>
@@ -36,11 +42,10 @@
 		<exclude name="WordPress.PHP.YodaConditions"/>
 
 		<!-- WP specific sniffs which should be ignored -->
+		<exclude name="WordPress.Security" />
 		<exclude name="WordPress.VIP" />
 		<exclude name="WordPress.WP" />
-		<exclude name="WordPress.XSS.EscapeOutput" />
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
-		<exclude name="WordPress.CSRF.NonceVerification" />
 		<exclude name="WordPress.PHP.DevelopmentFunctions" />
 		<exclude name="WordPress.PHP.DiscouragedPHPFunctions" />
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ matrix:
     - php: '7.0'
       env: GTEPHPFIVEFOUR=1
     - php: '7.1'
-      env: GTEPHPFIVEFOUR=1 SNIFF=1
-    - php: '7.2'
       env: GTEPHPFIVEFOUR=1
+    - php: '7.2'
+      env: GTEPHPFIVEFOUR=1 SNIFF=1
     - php: 'nightly'
       env: GTEPHPFIVEFOUR=1
 
@@ -56,10 +56,10 @@ before_install:
     # Install WordPress Coding Standards.
     - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR; fi
     # Install PHPCompatibility Standards in a subdirectory of WPCS so we only need to run installed_paths once.
-    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $PHPCOMPAT_DIR; fi
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/PHPCompatibility/PHPCompatibility.git $PHPCOMPAT_DIR; fi
     # Hop into CodeSniffer directory.
     - if [[ "$SNIFF" == "1" ]]; then cd $PHPCS_DIR; fi
-    # Set install path for WordPress Coding Standards.
+    # Set install path for PHP_CodeSniffer.
     # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
     - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/bin/phpcs --config-set installed_paths $WPCS_DIR,$PHPCOMPAT_DIR; fi
     # Hop back into project dir.

--- a/class.vartype.php
+++ b/class.vartype.php
@@ -107,7 +107,7 @@ class Vartype {
 		// Create the actual test functions.
 		foreach ( $this->tests as $key => $array ) {
 			// The cheatsheets are still compatible with PHP < 5.3, so there is no way round this.
-			// phpcs:ignore PHPCompatibility.PHP.DeprecatedFunctions.create_functionDeprecated,WordPress.PHP.RestrictedPHPFunctions.create_function_create_function,Generic.PHP.NoSilencedErrors.Discouraged
+			// phpcs:ignore PHPCompatibility.PHP.DeprecatedFunctions.create_functionDeprecated,Generic.PHP.DeprecatedFunctions.Deprecated,WordPress.PHP.RestrictedPHPFunctions.create_function_create_function,Generic.PHP.NoSilencedErrors.Discouraged
 			$this->tests[ $key ]['test'] = @create_function( $array['arg'], $array['function'] );
 		}
 	}


### PR DESCRIPTION
* Start using the PHPCS 3.x `basepath` and `parallel` options.
* PHPCompatibility has moved to its own organisation & released a new version `8.2.0`.
* WPCS has released a new version - `1.0.0`.
    - Update sniff exclusions in ruleset.
* Update inline ignore annotation.
* Test CS on PHP 7.2