### PR TITLE
Travis: test builds against PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,16 @@ matrix:
     - php: '7.1'
       env: GTEPHPFIVEFOUR=1
     - php: '7.2'
-      env: GTEPHPFIVEFOUR=1 SNIFF=1
+      env: GTEPHPFIVEFOUR=1
     - php: '7.3'
+      env: GTEPHPFIVEFOUR=1 SNIFF=1
+    - php: '7.4snapshot'
       env: GTEPHPFIVEFOUR=1
     - php: 'nightly'
       env: GTEPHPFIVEFOUR=1
 
   allow_failures:
+    - php: '7.4snapshot'
     - php: 'nightly'
 
 # Use this to prepare your build for testing.


### PR DESCRIPTION
Nightly has become PHP 8.0 since PHP 7.4 has been branched, so to continue to also test against PHP 7.4, it needs to be added separately.

Refs:
* https://twitter.com/nikita_ppv/status/1089839541828112384
* https://twitter.com/nikita_ppv/status/1094897743594770433

Includes moving the `SNIFF` build to PHP 7.3.