### PR TITLE
Composer: update dependencies

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -44,7 +44,6 @@
 
 		<!-- WP specific sniffs which should be ignored -->
 		<exclude name="WordPress.Security" />
-		<exclude name="WordPress.VIP" />
 		<exclude name="WordPress.WP" />
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 		<exclude name="WordPress.PHP.DevelopmentFunctions" />
@@ -54,7 +53,7 @@
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>
 
 		<!-- Declaring scope would break PHP4 compatibility. -->
-		<exclude name="Squiz.Scope.MemberVarScope"/>
+		<exclude name="PSR2.Classes.PropertyDeclaration"/>
 		<exclude name="Squiz.Scope.MethodScope"/>
 	</rule>
 

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
 	"require-dev" : {
 		"php" : ">=5.4",
 		"roave/security-advisories": "dev-master",
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
-		"wp-coding-standards/wpcs": "^1.0.0",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+		"wp-coding-standards/wpcs": "^2.0.0",
 		"phpcompatibility/php-compatibility": "^9"
 	},
 	"minimum-stability" : "RC",


### PR DESCRIPTION
* WPCS has released version 2.0.0, which removes the `VIP` sniff category and replaces the `Squiz.Scope.MemberVarScope` sniff with `PSR2.Classes.PropertyDeclaration`.
* DealerDirect has released version 0.5.0.