### PR TITLE
DevOps: update dependencies and other minor tweaks

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -48,6 +48,7 @@
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 		<exclude name="WordPress.PHP.DevelopmentFunctions" />
 		<exclude name="WordPress.PHP.DiscouragedPHPFunctions" />
+		<exclude name="WordPress.PHP.IniSet" />
 
 		<!-- Exclude a number of rules for being over-zealous for this codebase. -->
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 # Travis CI (MIT License) configuration file
 # @link https://travis-ci.org/
 
-# Use new container based environment
-sudo: false
-
 dist: trusty
 
 cache:

--- a/bin/autogen-static-sheets.php
+++ b/bin/autogen-static-sheets.php
@@ -270,7 +270,7 @@ if ( $GLOBALS['verbose'] > 0 ) {
 			'failures' => $failure,
 		)
 	);
-	echo "\nexit code" . $exit_code;
+	echo "\nexit code " . $exit_code;
 }
 
 exit( $exit_code );

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		"php" : ">=5.4",
 		"roave/security-advisories": "dev-master",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-		"wp-coding-standards/wpcs": "^2.0.0",
+		"wp-coding-standards/wpcs": "^2.1.0",
 		"phpcompatibility/php-compatibility": "^9"
 	},
 	"minimum-stability" : "RC",


### PR DESCRIPTION
* WPCS has released [version 2.1.0](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/releases/tag/2.1.0), which adds a new sniff we need to ignore.
* Travis will no longer support `sudo: false` in the near future.
* Minor script tweak.